### PR TITLE
Use empty string instead of undefined for initial search

### DIFF
--- a/src/frontend/features/search/hooks/useSearchEditor.tsx
+++ b/src/frontend/features/search/hooks/useSearchEditor.tsx
@@ -7,7 +7,7 @@ import { useAppStore } from "../../global/store/AppStore";
 
 import { FilterCondition, FilterConditionOperator } from "@/models/filter";
 import { Query, Search } from "@/models/search";
-import { SongMetadataTag } from "@/models/song";
+import { SongMetadataTag, SongMetadataValue } from "@/models/song";
 import { FilterUtils } from "@/utils/FilterUtils";
 import { SongTableUtils } from "@/utils/SongTableUtils";
 import { SongUtils } from "@/utils/SongUtils";
@@ -42,11 +42,17 @@ export function useSearchEditor() {
     return savedSearches?.map((v) => v.name) || [];
   }, [savedSearches]);
 
-  const defaultFilterCondition = (uuid: string) =>
+  const getDefaultFilterCondition = (uuid: string) =>
     FilterCondition.create({
       uuid,
       tag: SongMetadataTag.TITLE,
       operator: FilterConditionOperator.EQUAL,
+      value: SongMetadataValue.create({
+        value: {
+          $case: "stringValue",
+          stringValue: "",
+        },
+      }),
     });
 
   const [errorMessage, setErrorMessage] = useState("");
@@ -99,7 +105,7 @@ export function useSearchEditor() {
           });
           return;
         }
-        conditions.push(defaultFilterCondition(uuidv4()));
+        conditions.push(getDefaultFilterCondition(uuidv4()));
       });
       updateEditingSearch(newSearch, false);
     },
@@ -136,7 +142,7 @@ export function useSearchEditor() {
     const newSearch = produce(currentSearch, (draft) => {
       draft.queries!.push(
         Query.create({
-          conditions: [defaultFilterCondition(uuidv4())],
+          conditions: [getDefaultFilterCondition(uuidv4())],
         })
       );
     });

--- a/src/frontend/features/search/store/SearchSlice.ts
+++ b/src/frontend/features/search/store/SearchSlice.ts
@@ -8,7 +8,7 @@ import { FilterCondition, FilterConditionOperator } from "@/models/filter";
 import { MpdRequest } from "@/models/mpd/mpd_command";
 import { MpdProfile } from "@/models/mpd/mpd_profile";
 import { Query, SavedSearches, Search } from "@/models/search";
-import { Song, SongMetadataTag } from "@/models/song";
+import { Song, SongMetadataTag, SongMetadataValue } from "@/models/song";
 import { SongTableColumn } from "@/models/song_table";
 import { ApiUtils } from "@/utils/ApiUtils";
 import { FilterUtils } from "@/utils/FilterUtils";
@@ -25,6 +25,12 @@ function getDefaultSearch(): Search {
             uuid: uuidv4(),
             tag: SongMetadataTag.TITLE,
             operator: FilterConditionOperator.EQUAL,
+            value: SongMetadataValue.create({
+              value: {
+                $case: "stringValue",
+                stringValue: "",
+              },
+            }),
           }),
         ],
       }),


### PR DESCRIPTION
### Description

This PR makes sure that default search condition uses empty string instead of undefined.
