### PR TITLE
Use router.replace() instead of push()

### DIFF
--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -13,7 +13,7 @@ export default function Landing() {
 
   useEffect(() => {
     if (profile !== undefined) {
-      router.push(ROUTE_HOME_PLAY_QUEUE);
+      router.replace(ROUTE_HOME_PLAY_QUEUE);
     }
   }, [profile, router]);
 


### PR DESCRIPTION
### Description

This PR uses router.replace().
It was not necessary to go back to the landing page, and CSS didn't work with push().

Close #13 