### PR TITLE
feat: remove unnecessary suspense

### DIFF
--- a/packages/frontend/src/pages/RootLayout.tsx
+++ b/packages/frontend/src/pages/RootLayout.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from "react";
 import { Outlet } from "react-router-dom";
 
 import "allotment/dist/style.css";
@@ -7,16 +6,13 @@ import "ag-grid-community/styles/ag-grid.min.css";
 import "ag-grid-community/styles/ag-theme-alpine.min.css";
 import "../agGrid.css";
 import "../global.css";
-import { TopLoadingProgressBar } from "../features/loading";
 import { LocationObserver } from "../features/location";
 
 export function RootLayout() {
   return (
     <>
-      <Suspense fallback={<TopLoadingProgressBar />}>
-        <Outlet />
-        <LocationObserver />
-      </Suspense>
+      <Outlet />
+      <LocationObserver />
     </>
   );
 }


### PR DESCRIPTION
During development there used be an issue that a transition didn't work although no promise value were used for any components.
It seems it works well without Suspense.fallback now, so remove this.