### PR TITLE
chore: explicitly add build-base and python3 for node-gyp

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:22-alpine
 
+RUN apk add --no-cache build-base python3
+
 WORKDIR /app
 COPY . .
 RUN npm ci


### PR DESCRIPTION
fixes #228 